### PR TITLE
Return no effect when *Solid* value is returned by the device

### DIFF
--- a/pynanoleaf/pynanoleaf.py
+++ b/pynanoleaf/pynanoleaf.py
@@ -3,14 +3,15 @@ import requests
 
 logger = logging.getLogger(__name__)
 
+"""These effect names have special meaning and are not directly setable and should not be returned as effect name for Consumers."""
+RESERVED_EFFECT_NAMES = ["*Solid*", "*Static*", "*Dynamic*"]
+
 
 def _deepgetter(key):
     """Retrieve value from nested dicts"""
     def get(data):
         for k in key:
             data = data[k]
-        if ('.'.join(key) == 'effects.select'):
-            return _parseEffect(data)
         return data
     return get
 
@@ -35,9 +36,6 @@ def _dictitem_property(keystr):
     )
 
 def _parseEffect(effect):
-    """These effect names have special meaning and are not directly setable
-    and should not be returned as effect name for Consumers."""
-    RESERVED_EFFECT_NAMES = ["*Solid*", "*Static*", "*Dynamic*"]
     try:
         RESERVED_EFFECT_NAMES.index(effect)
         return None
@@ -52,10 +50,6 @@ class _Info(dict):
     firmwareVersion = _dictitem_property('firmwareVersion')
     model = _dictitem_property('model')
     name = _dictitem_property('name')
-    manufacturer = _dictitem_property('manufacturer')
-    hardwareVersion = _dictitem_property('hardwareVersion')
-    effects = _dictitem_property('effects.effectsList')
-    effectSelect = _dictitem_property('effects.select')
 
 
 class _State(dict):

--- a/pynanoleaf/pynanoleaf.py
+++ b/pynanoleaf/pynanoleaf.py
@@ -9,6 +9,8 @@ def _deepgetter(key):
     def get(data):
         for k in key:
             data = data[k]
+        if ('.'.join(key) == 'effects.select'):
+            return _parseEffect(data)
         return data
     return get
 
@@ -32,6 +34,15 @@ def _dictitem_property(keystr):
         fset=_deepsetter(key)
     )
 
+def _parseEffect(effect):
+    """These effect names have special meaning and are not directly setable and should not be returned as effect name for Consumers."""
+    RESERVED_EFFECT_NAMES = ["*Solid*", "*Static*", "*Dynamic*"]
+    try:
+        RESERVED_EFFECT_NAMES.index(effect)
+        return None
+    except ValueError:
+        return effect
+
 
 class _Info(dict):
     """General info about the Nanoleaf"""
@@ -40,6 +51,10 @@ class _Info(dict):
     firmwareVersion = _dictitem_property('firmwareVersion')
     model = _dictitem_property('model')
     name = _dictitem_property('name')
+    manufacturer = _dictitem_property('manufacturer')
+    hardwareVersion = _dictitem_property('hardwareVersion')
+    effects = _dictitem_property('effects.effectsList')
+    effectSelect = _dictitem_property('effects.select')
 
 
 class _State(dict):
@@ -249,8 +264,7 @@ class Nanoleaf(object):
 
     @property
     def effect(self):
-        effect = self._get("effects/select")
-        return effect if effect != '*Solid*' else None
+        return _parseEffect(self._get("effects/select"))
 
     @effect.setter
     def effect(self, value):

--- a/pynanoleaf/pynanoleaf.py
+++ b/pynanoleaf/pynanoleaf.py
@@ -35,7 +35,8 @@ def _dictitem_property(keystr):
     )
 
 def _parseEffect(effect):
-    """These effect names have special meaning and are not directly setable and should not be returned as effect name for Consumers."""
+    """These effect names have special meaning and are not directly setable
+    and should not be returned as effect name for Consumers."""
     RESERVED_EFFECT_NAMES = ["*Solid*", "*Static*", "*Dynamic*"]
     try:
         RESERVED_EFFECT_NAMES.index(effect)

--- a/pynanoleaf/pynanoleaf.py
+++ b/pynanoleaf/pynanoleaf.py
@@ -36,10 +36,9 @@ def _dictitem_property(keystr):
     )
 
 def _parseEffect(effect):
-    try:
-        RESERVED_EFFECT_NAMES.index(effect)
+    if effect in RESERVED_EFFECT_NAMES:
         return None
-    except ValueError:
+    else:
         return effect
 
 

--- a/pynanoleaf/pynanoleaf.py
+++ b/pynanoleaf/pynanoleaf.py
@@ -249,7 +249,8 @@ class Nanoleaf(object):
 
     @property
     def effect(self):
-        return self._get("effects/select")
+        effect = self._get("effects/select")
+        return effect if effect != '*Solid*' else None
 
     @effect.setter
     def effect(self, value):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='pynanoleaf',
-    version='0.0.7',
+    version='0.0.8',
     author='Marco Orovecchia',
     author_email='pynanoleaf@marco.orovecchia.com',
     url='https://github.com/Oro/pynanoleaf',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='pynanoleaf',
-    version='0.0.8',
+    version='0.0.7',
     author='Marco Orovecchia',
     author_email='pynanoleaf@marco.orovecchia.com',
     url='https://github.com/Oro/pynanoleaf',


### PR DESCRIPTION
Canvas device returns the value '*Solid*' as current effect selected but there is really no effect selected.