### PR TITLE
Fix color_mode property

### DIFF
--- a/pynanoleaf/pynanoleaf.py
+++ b/pynanoleaf/pynanoleaf.py
@@ -254,7 +254,7 @@ class Nanoleaf(object):
 
     @property
     def color_mode(self):
-        return self._get("state/colorMode")['value']
+        return self._get("state/colorMode")
 
     @property
     def effect(self):


### PR DESCRIPTION
The API returns a string on the `state/colorMode` endpoint. I tested this on a Nanoleaf Canvas. And it's also in the Nanoleaf API docs: https://forum.nanoleaf.me/docs/openapi#_qdwinqtjqeul

The current property implementation doesn't work, it raises: `TypeError: string indices must be integers`.

The property tries to get `value` from a string, instead it should return the string.

---
Request made to a Nanoleaf Canvas:
![colormode](https://user-images.githubusercontent.com/15276289/131333035-5a3e00ea-87d6-45b5-bd72-66cd465a5846.png)
